### PR TITLE
[TASK] Update dev dependencies

### DIFF
--- a/Build/php-cs-fixer.php
+++ b/Build/php-cs-fixer.php
@@ -78,7 +78,7 @@ return (new \PhpCsFixer\Config())
         'no_short_bool_cast' => true,
         'no_singleline_whitespace_before_semicolons' => true,
         'no_superfluous_elseif' => true,
-        'no_trailing_comma_in_singleline_array' => true,
+        'no_trailing_comma_in_singleline' => true,
         'no_unneeded_control_parentheses' => true,
         'no_unused_imports' => true,
         'no_useless_else' => true,

--- a/Tests/Unit/Imaging/IconProvider/FontawesomeIconProviderTest.php
+++ b/Tests/Unit/Imaging/IconProvider/FontawesomeIconProviderTest.php
@@ -54,7 +54,7 @@ class FontawesomeIconProviderTest extends TestCase
      *
      * @return array<string, array<int, string|int>>
      */
-    public function wrongNamesDataProvider(): array
+    public static function wrongNamesDataProvider(): array
     {
         return [
             'name with spaces' => ['name with spaces', 1440754979],

--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,10 @@
         "typo3/cms-core": "^11.5 || ^12.0 || 12.*.*@dev"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.9",
-        "phpstan/phpstan": "^1.8",
-        "phpstan/phpstan-phpunit": "^1.1",
-        "phpunit/phpunit": "^9.5"
+        "friendsofphp/php-cs-fixer": "^3.14",
+        "phpstan/phpstan": "^1.9",
+        "phpstan/phpstan-phpunit": "^1.3",
+        "phpunit/phpunit": "^9.6"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,


### PR DESCRIPTION
The following dev dependencies are updated to their corresponding latest version:

* `friendsofphp/php-cs-fixer`
* `phpstan/phpstan`
* `phpstan/phpstan-phpunit`
* `phpunit/phpunit`

`phpunit/phpunit` v10 was releases a few days ago, but cannot be used due to dependency issues with `friendsofphp/php-cs-fixer`. As a preparation for the eventual update, the `FontawesomeIconProviderTest` received a slight adjustment.