### PR TITLE
[BUGFIX] Run Github CI on pull requests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [ push ]
+on: [ push, pull_request ]
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
 
 jobs:
   ci:


### PR DESCRIPTION
Always run the CI workflow on pull requests, solving an issue when CI didn't start when PRs were created from forks.

Also, `concurrency` is now configured to automatically cancel any running build for the same ref if new changes are pushed.